### PR TITLE
Optimize performance: split extractors into three groups

### DIFF
--- a/src/main/java/de/turing85/quarkus/camel/xml/stream/processor/xml/ValueExtractor.java
+++ b/src/main/java/de/turing85/quarkus/camel/xml/stream/processor/xml/ValueExtractor.java
@@ -45,7 +45,7 @@ class ValueExtractor implements XMLExtractor {
   }
 
   @Override
-  public void handleEventRecording(XMLEvent event, List<String> path) {
+  public void recordEvent(XMLEvent event, List<String> path) {
     if (recordValue && event.isCharacters()) {
       writer.append(event.asCharacters().getData());
     }

--- a/src/main/java/de/turing85/quarkus/camel/xml/stream/processor/xml/XMLExtractor.java
+++ b/src/main/java/de/turing85/quarkus/camel/xml/stream/processor/xml/XMLExtractor.java
@@ -8,9 +8,21 @@ import javax.xml.stream.events.StartElement;
 import javax.xml.stream.events.XMLEvent;
 
 public interface XMLExtractor {
+  default boolean handlesStartEvents() {
+    return true;
+  }
+
   void handleStartElement(StartElement startElement, List<String> path) throws Exception;
 
-  void handleEventRecording(XMLEvent event, List<String> path) throws Exception;
+  default boolean recordsEvents() {
+    return true;
+  }
+
+  void recordEvent(XMLEvent event, List<String> path) throws Exception;
+
+  default boolean handlesEndEvents() {
+    return true;
+  }
 
   void handleEndElement(EndElement endElement, List<String> path) throws Exception;
 

--- a/src/test/resources/input.xml
+++ b/src/test/resources/input.xml
@@ -17,4 +17,6 @@
 </bongo>
         </response>
     </bing>
+    <empty/>
+    <anotherEmpty></anotherEmpty>
 </foo>


### PR DESCRIPTION
Optimize performance: split extractors into three groups (handles start events, records events,  handles stop events).

In the corresponding parsing phase, only the extractors that are in the group are called. Each extractor can be in multiple groups.