### PR TITLE
Performance Optimizations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -360,19 +360,11 @@
         <!-- Camel Quarkus dependencies -->
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>
-            <artifactId>camel-quarkus-rest</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.camel.quarkus</groupId>
-            <artifactId>camel-quarkus-direct</artifactId>
+            <artifactId>camel-quarkus-platform-http</artifactId>
         </dependency>
         <dependency>
             <groupId>jakarta.ws.rs</groupId>
             <artifactId>jakarta.ws.rs-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.camel.quarkus</groupId>
-            <artifactId>camel-quarkus-log</artifactId>
         </dependency>
 
         <!-- Test dependencies -->

--- a/src/main/java/de/turing85/quarkus/camel/xml/stream/XmlRoute.java
+++ b/src/main/java/de/turing85/quarkus/camel/xml/stream/XmlRoute.java
@@ -1,7 +1,7 @@
 package de.turing85.quarkus.camel.xml.stream;
 
-import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.TreeMap;
 
 import jakarta.inject.Singleton;
@@ -27,12 +27,10 @@ public class XmlRoute extends RouteBuilder {
         .httpMethodRestrict(HttpMethod.POST.name())
         .consumes(MediaType.APPLICATION_XML)
         .produces(MediaType.APPLICATION_XML))
-        .log("charset = ${header.%s}".formatted(Exchange.CHARSET_NAME))
         .setProperty(XmlProcessor.PROPERTY_NAME_ADDITIONAL_VALUES_TO_EXTRACT,
-            constant(List.of("bang", "bongo")))
+            constant(Set.of("bang", "bongo")))
         .process(processor)
         .process(XmlRoute::constructBody)
-        .convertBodyTo(byte[].class, "UTF-8")
     ;
     // @formatter:on
   }

--- a/src/main/java/de/turing85/quarkus/camel/xml/stream/processor/xml/XMLExtractor.java
+++ b/src/main/java/de/turing85/quarkus/camel/xml/stream/processor/xml/XMLExtractor.java
@@ -1,8 +1,8 @@
 package de.turing85.quarkus.camel.xml.stream.processor.xml;
 
 import java.util.List;
-import java.util.Set;
 
+import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.events.EndElement;
 import javax.xml.stream.events.StartElement;
 import javax.xml.stream.events.XMLEvent;
@@ -12,19 +12,19 @@ public interface XMLExtractor {
     return true;
   }
 
-  void handleStartElement(StartElement startElement, List<String> path) throws Exception;
+  void handleStartElement(StartElement startElement, int depth) throws XMLStreamException;
 
   default boolean recordsEvents() {
     return true;
   }
 
-  void recordEvent(XMLEvent event, List<String> path) throws Exception;
+  void recordEvent(XMLEvent event, int depth) throws XMLStreamException;
 
   default boolean handlesEndEvents() {
     return true;
   }
 
-  void handleEndElement(EndElement endElement, List<String> path) throws Exception;
+  void handleEndElement(EndElement endElement, int depth) throws XMLStreamException;
 
-  Set<String> getValues();
+  List<String> getValues();
 }

--- a/src/test/resources/expected.xml
+++ b/src/test/resources/expected.xml
@@ -2,6 +2,7 @@
     <request>
 <baz>
     <bang>1337</bang>
+    <bang>42</bang>
     <request>
 <boom>42</boom>
     </request>

--- a/src/test/resources/input.xml
+++ b/src/test/resources/input.xml
@@ -4,6 +4,7 @@
         <request>
 <baz>
     <bang>1337</bang>
+    <bang>42</bang>
     <request>
 <boom>42</boom>
     </request>
@@ -19,4 +20,376 @@
     </bing>
     <empty/>
     <anotherEmpty></anotherEmpty>
+    <root>
+        <listing>
+            <seller_info>
+                <seller_name>537_sb_3 </seller_name>
+                <seller_rating> 0</seller_rating>
+            </seller_info>
+            <payment_types>Visa, Mastercard, , , , 0, Discover, American Express </payment_types>
+            <shipping_info>siteonly, Buyer Pays Shipping Costs </shipping_info>
+            <buyer_protection_info> </buyer_protection_info>
+            <auction_info>
+                <current_bid> $839.93</current_bid>
+                <time_left> 1 Day, 6 Hrs</time_left>
+                <high_bidder>
+                    <bidder_name> </bidder_name>
+                    <bidder_rating> </bidder_rating>
+                </high_bidder>
+                <num_items> 5</num_items>
+                <num_bids> 0</num_bids>
+                <started_at> $839.93</started_at>
+                <bid_increment> </bid_increment>
+                <location> Englewood , Utah, United States</location>
+                <opened> 11/25/00 7:46:16 PM</opened>
+                <closed> 11/28/00 7:46:16 PM</closed>
+                <id_num> 315914 </id_num>
+                <notes> </notes>
+            </auction_info>
+            <bid_history>
+                <highest_bid_amount>839.93 </highest_bid_amount>
+                <quantity>0 </quantity>
+            </bid_history>
+            <item_info>
+                <memory> </memory>
+                <hard_drive> </hard_drive>
+                <cpu> </cpu>
+                <brand> </brand>
+                <description>AMD Athlon 900 Mhz Processor. New K7 CPU comes with a year warranty. Rated gamers paradise in all reviews and high benchmark ratings. Days To Ship: 5 </description>
+            </item_info>
+        </listing>
+        <listing>
+            <seller_info>
+                <seller_name> lapro8</seller_name>
+                <seller_rating> 0</seller_rating>
+            </seller_info>
+            <payment_types>Money Order </payment_types>
+            <shipping_info>International Shipping, See Shipping Description </shipping_info>
+            <buyer_protection_info> </buyer_protection_info>
+            <auction_info>
+                <current_bid> $210.00</current_bid>
+                <time_left> 4 Days, 21 Hrs</time_left>
+                <high_bidder>
+                    <bidder_name> </bidder_name>
+                    <bidder_rating> </bidder_rating>
+                </high_bidder>
+                <num_items> 1</num_items>
+                <num_bids> 0</num_bids>
+                <started_at> $210.00</started_at>
+                <bid_increment> $5.00</bid_increment>
+                <location>Cherkasy, Ukraine </location>
+                <opened> 11/27/00 11:15:34 AM</opened>
+                <closed> 12/2/00 11:15:34 AM</closed>
+                <id_num> 320761</id_num>
+                <notes> </notes>
+            </auction_info>
+            <bid_history>
+                <highest_bid_amount>$210.00 </highest_bid_amount>
+                <quantity>0 </quantity>
+            </bid_history>
+            <item_info>
+                <memory> 64MB Ram(Maximum - 256 MB)</memory>
+                <hard_drive> 4 GB Removable Hard Drive</hard_drive>
+                <cpu> Intel Pentium II 266MHZ MMX</cpu>
+                <brand> Compaq</brand>
+                <description> Compaq Armada 7400 Intel Pentium II 266MHZ MMX LAPTOP!!!! This laptop looks and feels solid! The screen is huge, the keyboard feels good, the mouse moves just right! Internet Ready! Its Features are as Follows: Intel Mobile PentiumR II processor 266 MHz- very fast!! 512KB L2 Cache 64MB Ram (Maximum - 256 MB ) 4 GB Removable Hard Drive 13.3 CTFT 1024 x 768 panel ( huge and very nice!) Windows 95 included!! AGP implementation with dedicated 66-MHz graphics bus. Frame mode support S3 ViRGE/MXTM graphics controller with 4 MB of 100 MHz SGRAM. Up to 100 Hz external refresh at SVGA resolution up to 16.8 million colors. Simultaneous display support in any resolutions. 16-bit Compaq PremierSoundTM and Hardware Wave Table for enhanced audio (16-bit Sound Blaster Pro compatible), integrated stereo speakers and Bass Reflex speaker ports, integrated microphone, hardware and software volume control, headphone, microphone and stereo line-in jacks, standard CD-ROM or DVD-ROM Drive, software MPEG1 and software MPEG2 available (sounds crisp) AC Adapter and Battery works (but the life of the battery is not warranted) 3.5 Floppy Drive (swappable) 24X CD-ROM (swappable) MORE INFO: PC Card Slots Two Type II/One Type III PC Card Slot(s), which support both 32-bit CardBus9 and 16-bit PC Cards; Zoomed Video support in bottom slot only; telephony support in top slot only Interfaces PC Card Two Type II/One Type III Enhanced Parallel 1 Serial 1 External Monitor 1 External Keyboard/Pointing Device (PS/2) 1 Convenience Base 1 Headphone/Line out 1 Stereo Line In 1 Microphone 1 AC Power 1 RJ 11 1 Infrared 1 (4 Mb/s10 support) Expansion Base 1 USB 1 Support for Third-Party Y-Cables (for external mouse and keyboard) Yes Buyer have to pay by money order. Please add $30 for shipping (includes insurance) International shipping additional. </description>
+            </item_info>
+        </listing>
+        <listing>
+            <seller_info>
+                <seller_name> aboutlaw</seller_name>
+                <seller_rating> 0</seller_rating>
+            </seller_info>
+            <payment_types>American Express, Discover, MasterCard, Visa </payment_types>
+            <shipping_info>Other Shipping Service, UPS </shipping_info>
+            <buyer_protection_info> </buyer_protection_info>
+            <auction_info>
+                <current_bid> $1,049.00 </current_bid>
+                <time_left> 5 Days, 20 Hrs</time_left>
+                <high_bidder>
+                    <bidder_name> </bidder_name>
+                    <bidder_rating> </bidder_rating>
+                </high_bidder>
+                <num_items> 9</num_items>
+                <num_bids> 0 </num_bids>
+                <started_at>$1,049.00 </started_at>
+                <bid_increment> </bid_increment>
+                <location> seattel, Washington, United States</location>
+                <opened> 11/18/00 9:42:39 AM</opened>
+                <closed> 12/3/00 9:42:39 AM</closed>
+                <id_num> 299664</id_num>
+                <notes> </notes>
+            </auction_info>
+            <bid_history>
+                <highest_bid_amount>$1,049.00 </highest_bid_amount>
+                <quantity> 0</quantity>
+            </bid_history>
+            <item_info>
+                <memory> 64MB</memory>
+                <hard_drive> 20GB</hard_drive>
+                <cpu> Celeron 600MHz</cpu>
+                <brand> </brand>
+                <description> Computers, desktops, printers, software Great prices and great value on all computers: WebPC CeleronAMD Athlon 900 Mhz Processor. New K7 CPU comes with a year warranty. Rated gamers paradise in all reviews and high benchmark ratings. Days To Ship: 5 We gladly accept: Not quite what you are looking for? See our similar products currently up for bid. Have a question about Shipping, Returns Policy, Our Company or anything else? Click Here. 600MHz Computer Bundle with 17 Monitor 600MHz / 64MB / 20GB / 50x CD-ROM / 4x4x32 CD-RW / 56k / 17 Monitor This package gives you a high-performance computer and 17 monitor an amazingly affordable price. The computer, a WebPC, has a 600MHz Intel. Celeron. processor, a 20GB hard drive, and 64 MB 100MHz SDRAM to keep your machine moving quick... [more] After Rebate: $999.00 </description>
+            </item_info>
+        </listing>
+        <listing>
+            <seller_info>
+                <seller_name>1137_sb_8 </seller_name>
+                <seller_rating> 0</seller_rating>
+            </seller_info>
+            <payment_types>Visa, Mastercard, Personal Check, MOney Order, , 0, , American Express </payment_types>
+            <shipping_info>Irving, Utah, United States </shipping_info>
+            <buyer_protection_info> </buyer_protection_info>
+            <auction_info>
+                <current_bid> No Bids</current_bid>
+                <time_left> 1 Day, 2 Hrs</time_left>
+                <high_bidder>
+                    <bidder_name> </bidder_name>
+                    <bidder_rating> </bidder_rating>
+                </high_bidder>
+                <num_items> 1</num_items>
+                <num_bids> 0</num_bids>
+                <started_at> $650.00</started_at>
+                <bid_increment> $10.00</bid_increment>
+                <location> Irving, Utah, United States</location>
+                <opened> 11/25/00 3:42:50 PM</opened>
+                <closed> 11/28/00 3:42:50 PM</closed>
+                <id_num> 314115</id_num>
+                <notes> </notes>
+            </auction_info>
+            <bid_history>
+                <highest_bid_amount>No Bids </highest_bid_amount>
+                <quantity> 0</quantity>
+            </bid_history>
+            <item_info>
+                <memory> 32MB RAM</memory>
+                <hard_drive> 2.1GB hard driv</hard_drive>
+                <cpu> Pentium 166</cpu>
+                <brand> </brand>
+                <description> Pentium 166, 32MB RAM, 2.1GB hard drive, cd-rom drive, Floppy drive, 12.1' TFT Color Screen, Battery and AC Adapter, 28.8K integrated modem. Fully licensed Windows 95 pre-installed for your convenience. This usedl aptop is Internet Ready. Add 16MB for $48 and 32MB more for $110. Upgrade to 56K modem for $65. </description>
+            </item_info>
+        </listing>
+        <listing>
+            <seller_info>
+                <seller_name> 537_sb_3</seller_name>
+                <seller_rating> 0</seller_rating>
+            </seller_info>
+            <payment_types>Visa, Mastercard, , , , 0, Discover, American Express </payment_types>
+            <shipping_info>siteonly, Buyer Pays Shipping Costs </shipping_info>
+            <buyer_protection_info> </buyer_protection_info>
+            <auction_info>
+                <current_bid> $657.52</current_bid>
+                <time_left> 1 Day, 4 Hrs</time_left>
+                <high_bidder>
+                    <bidder_name> </bidder_name>
+                    <bidder_rating> </bidder_rating>
+                </high_bidder>
+                <num_items> 5</num_items>
+                <num_bids> 0</num_bids>
+                <started_at> $657.52</started_at>
+                <bid_increment> </bid_increment>
+                <location> Englewood , Utah, United States</location>
+                <opened> 11/25/00 5:24:20 PM</opened>
+                <closed> 11/28/00 5:24:20 PM</closed>
+                <id_num> 314815</id_num>
+                <notes> </notes>
+            </auction_info>
+            <bid_history>
+                <highest_bid_amount>$657.52 </highest_bid_amount>
+                <quantity>0 </quantity>
+            </bid_history>
+            <item_info>
+                <memory> </memory>
+                <hard_drive> </hard_drive>
+                <cpu> </cpu>
+                <brand> </brand>
+                <description> We gladly accept: Not quite what you are looking for? See our similar products currently up for bid. Have a question about Shipping, Returns Policy, Our Company or anything else? Click Here. </description>
+            </item_info>
+        </listing>
+        <listing>
+            <seller_info>
+                <seller_name>42_sb_691 </seller_name>
+                <seller_rating> 1</seller_rating>
+            </seller_info>
+            <payment_types>Visa, Mastercard, Personal Check, , , 0, Discover, American Express </payment_types>
+            <shipping_info>International Shipping, Buyer Pays Shipping Costs </shipping_info>
+            <buyer_protection_info> </buyer_protection_info>
+            <auction_info>
+                <current_bid> $2,631.00</current_bid>
+                <time_left> 1 Day, 4 Hrs</time_left>
+                <high_bidder>
+                    <bidder_name> </bidder_name>
+                    <bidder_rating> </bidder_rating>
+                </high_bidder>
+                <num_items> 3</num_items>
+                <num_bids> 0</num_bids>
+                <started_at> $2,631.00</started_at>
+                <bid_increment> </bid_increment>
+                <location> Indianapolis, Utah, United States</location>
+                <opened> 11/25/00 5:54:53 PM</opened>
+                <closed> 11/28/00 5:54:53 PM</closed>
+                <id_num> 315092</id_num>
+                <notes> </notes>
+            </auction_info>
+            <bid_history>
+                <highest_bid_amount>$2,631.00 </highest_bid_amount>
+                <quantity> 0</quantity>
+            </bid_history>
+            <item_info>
+                <memory> 64 MB</memory>
+                <hard_drive> 12 GB</hard_drive>
+                <cpu> 650 MHz</cpu>
+                <brand> Hewlett-Packard </brand>
+                <description> Manufacturer Part # Manufacturer Hewlett-Packard System: Type Portable System: Form Factor Notebook System: BIOS Vendor Specific Processor: Installed Brand Intel Processor: Class Intel Pentium III Processor: Speed (MHz) 650 MHz Processor: Max Upgrade Supported (MHz) Not Upgradable Processor: Brands Supported Intel Processor: Max Number Supported Single Processor Processor: Socket Type/Chipset Pin Grid Array (PGA) Socket Memory: Installed Amount 64 MB Memory: Max Amount Supported 192 MB Memory: Type/Style Installed/Supported SDRAM Memory: Number of Pins Vendor Specific Memory: Number of Sockets (2) Vendor Specific Memory: Speed Vendor Specific Memory: Must Be Added In Singles Cache: Installed Amount 256 KB Synchronous Pipeline Burst Cache: Max Amount 256 KB Hard Drive: Formatted Capacity 12 GB Hard Drive: Type Interface EIDE Other Storage 1.44 MB Floppy Drive Device Controller: Type Included Integrated Device Controller: Bus Type Integrated Device Controller: Cable Included Yes Communication: Fax/Modem None Included Communication: Network None Included Keyboard 87 Key Integrated Keyboard Pointing Device Integrated Trackstick Integrated TouchPad Video Card: Bus Type AGP Integrated Video Card: Manufacturer/Chipset 2D/3D Graphics Accelerator Video Card: Max Standard/Max Resolution XGA 1024 x 768 Video Card: Memory Amount Included 2.5 MB Video Card: Max Memory Supported Not Upgradeable Video Card: Memory Type VRAM Video Card: Features MPEG II Zoomed Video (ZV) Port Notebook Display: Type Screen 13.3in Diagonal Active TFT Matrix Dimensions: 11.8 W 8.8 W 1.26 in (30 W 22.5 W 3.2 cm) or 11.95 x 9.3 x 1.4 in (30.4 x 23.7 x 3.5 cm) Weight: 4.0 lb (1.79 kg) Notebook Display: Max Resolution 1024 x 768 Built-in Audio Features Built-in Microphone Built-in 16-bit Stereo Audio Product Code: NBKHP136 </description>
+            </item_info>
+        </listing>
+        <listing>
+            <seller_info>
+                <seller_name> 42_sb_691</seller_name>
+                <seller_rating> 1</seller_rating>
+            </seller_info>
+            <payment_types>Visa, Mastercard, Personal Check, , , 0, Discover, American Express </payment_types>
+            <shipping_info>International Shipping, Buyer Pays Shipping Costs </shipping_info>
+            <buyer_protection_info> </buyer_protection_info>
+            <auction_info>
+                <current_bid> $2,618.00</current_bid>
+                <time_left> 1 Day, 8 Hrs</time_left>
+                <high_bidder>
+                    <bidder_name> </bidder_name>
+                    <bidder_rating> </bidder_rating>
+                </high_bidder>
+                <num_items> 3</num_items>
+                <num_bids> 0</num_bids>
+                <started_at> 11/25/00 9:58:02 PM</started_at>
+                <bid_increment> </bid_increment>
+                <location> Indianapolis, Utah, United States</location>
+                <opened> 11/25/00 9:58:02 PM</opened>
+                <closed> 11/28/00 9:58:02 PM</closed>
+                <id_num> 316215</id_num>
+                <notes> </notes>
+            </auction_info>
+            <bid_history>
+                <highest_bid_amount>$2,618.00 </highest_bid_amount>
+                <quantity> 0</quantity>
+            </bid_history>
+            <item_info>
+                <memory> 64Mbit SDRAM, expandable to 320MB 3.3V, 60ns</memory>
+                <hard_drive> 12 GB hard disk drive</hard_drive>
+                <cpu> Mobile Intel. 700 MHz Pentium. III processor featuring Intel SpeedStep</cpu>
+                <brand> </brand>
+                <description> Display 15. 0 diagonal (1024 x 768) Internal display supports up to 16M colors at 800 x 600 and 64K colors at 1024 x 768 External Color Support 800 x 600 and 640 x 480; 60/70/85Hz Non-Interlaced @ 16M 1024 x 768; 60Hz Non-Interlaced @ 16M 1600 x 1200; 60Hz Non-Interlaced @ 64K Processor Mobile Intel. 700 MHz Pentium. III processor featuring Intel SpeedStepVisa, Mastercard, Personal Check, , , 0, Discover, American Express Technology. 100MHz Front Side Bus Data/Address Bus Width: 64-bit/32-bit Integrated co-processor Cache Memory 256KB Level 2 cache integrated on die 32KB internal cache System Memory 64Mbit SDRAM, expandable to 320MB 3.3V, 60ns Internal memory expansion slot BIOS APM V1.2; ACPI V1.2; PnP V1.0a; VESA V2.0; DPMS; DDC2B; DMI 2.0, SM BIOS V2.3, PCI BIOS V2.2 System Architecture PCI Bus V2.2 Keyboard Full sized 85 keys with 12 function keys Pointing Device Integrated AccuPoint. II pointing device with scroll buttons Communications Integrated V.90/K56flex modem Storage Drive 12 GB hard disk drive -13ms average access time -Supports PIO Mode4 or Ultra DMA33 Mode2 Built-in 6X max. speed DVD-ROM (130 ms access time) integrated 3.5-inch, 1.44-MB floppy disk drive Video S3 Savage IX Graphics Controller 64-BIT graphics accelerator 2x AGP bus 128 BitBLT hardware 8MB internal video memory Audio Yamaha YMF744B-R 3D sound support with HRTF 3D positional audio 16-bit stereo, .WAV and Sound Blaster. Pro compatible, MIDI playback 2 built-in stereo speakers 64-channel wavetable music synthesis Full duplex sound support Hardware acceleration for DirectMusic and DirectSound Microphone and Headphone ports Expansion Two PC Card slots support two Type II or one Type III PC Cards; 32-bit CardBus ready SVGA video port Fast infrared port (4Mbps, IrDA V1.1 compliant) PS/2Visa, Mastercard, Personal Check, , , 0, Discover, American Express mouse/keyboard port (Y-connector supported) Universal Serial Bus port ECP parallel port High speed serial port (16550 UART compatible) Port Replicator connector Headphone jack, Microphone port RJ-11 port Composite Video Port Preinstalled Operating System Windows 98SE Additional Software Customizable Toshiba/My Yahoo! Start Page Microsoft Internet Explorer McAfee ActiveShield RingCentralVisa, Mastercard, Personal Check, , , 0, Discover, American Express (Windows 98 Second Edition only) MediaMatics DVDExpress Toshiba Custom Utilities Satellite Series Online Documentation Toshiba VirtualTech Toshiba Great Software Offer: With each Satellite notebook, you will receive your choice of two software titles. The software selection includes titles from the following: Lotus. SmartSuite Millennium Edition, productivity, education/reference, creativity and entertainment titles. Security Power-on password (2-level password support) HDD access password Main system memory modem and internal HDD security screws included Cable lock slot SecureSleep (Screen Blank) Keyboard Lock Battery Rechargeable, removable Lithium Ion battery (10.8V, 4,000mAh) 2.5+ hours battery life Recharge time: 3 hrs unit off, 4-10 hrs unit on ACPI V1.0 support Battery life may vary depending on applications, power management settings and features utilized. Recharge time varies depending on usage. Dimensions 122. x 103. x 17. Weight 7.0 lbs Warranty 1 year parts, labor and battery </description>
+            </item_info>
+        </listing>
+        <listing>
+            <seller_info>
+                <seller_name>okcbuy </seller_name>
+                <seller_rating> 0</seller_rating>
+            </seller_info>
+            <payment_types>American Express, Discover, Internet Escrow, iEscrow, MasterCard, Money Order, Visa </payment_types>
+            <shipping_info>Buyer Pays Shipping Costs, FedEx, UPS </shipping_info>
+            <buyer_protection_info> </buyer_protection_info>
+            <auction_info>
+                <current_bid> $1.00</current_bid>
+                <time_left>1 Day, 17 Hrs </time_left>
+                <high_bidder>
+                    <bidder_name> </bidder_name>
+                    <bidder_rating> </bidder_rating>
+                </high_bidder>
+                <num_items> 1</num_items>
+                <num_bids> 0</num_bids>
+                <started_at> $1.00</started_at>
+                <bid_increment> $0.10</bid_increment>
+                <location> Oklahoma City, Oklahoma, United States</location>
+                <opened> 11/14/00 7:27:50 AM</opened>
+                <closed> 11/29/00 7:27:50 AM</closed>
+                <id_num> 291907</id_num>
+                <notes> </notes>
+            </auction_info>
+            <bid_history>
+                <highest_bid_amount>$1.00 </highest_bid_amount>
+                <quantity> 0</quantity>
+            </bid_history>
+            <item_info>
+                <memory> 64MB 100MHz SDRAM expandable to 768MB</memory>
+                <hard_drive> 8.4GB 5400RPM Ultra ATA hard drive</hard_drive>
+                <cpu> AMD K6-2 500MHz with 3DNow!</cpu>
+                <brand> </brand>
+                <description> Processor: AMD K6-2 500MHz with 3DNow! Mother Board: Super Socket 7 w/1MB Cache, 100MHz buss, &amp; 16 bit on-board sound Memory: 64MB 100MHz SDRAM expandable to 768MB Graphics Accelerator: ATI Expert 99, 8MB AGP Graphics Sound: 192XGD Wave Force PCI by Yamaha Case: 4-bay ATX Mid Tower Easy Access w/removable tray Keyboard:104 Key PS/2 Style Keyboard Mouse:2 Button PS/2 Style Mouse Hard Drive: 8.4GB 5400RPM Ultra ATA hard drive CD-ROM: 50X CD-ROM Drive Floppy Drive: Sony 3.5 1.44MB diskette drive Fax/Modem: Integrated V.90 56K Data/Fax/Voice Modem Speakers: Labtech LCS-0120 </description>
+            </item_info>
+        </listing>
+        <listing>
+            <seller_info>
+                <seller_name> bell25</seller_name>
+                <seller_rating> 0</seller_rating>
+            </seller_info>
+            <payment_types>American Express, C.O.D., Discover, Internet Escrow, iEscrow, MasterCard, Money Order, Personal Check, Visa </payment_types>
+            <shipping_info>Buyer Pays Shipping Costs, FedEx, Other Shipping Service, UPS, USPS </shipping_info>
+            <buyer_protection_info> </buyer_protection_info>
+            <auction_info>
+                <current_bid> $650.00</current_bid>
+                <time_left> 3 Days, 3 Hrs</time_left>
+                <high_bidder>
+                    <bidder_name> </bidder_name>
+                    <bidder_rating> </bidder_rating>
+                </high_bidder>
+                <num_items> 1</num_items>
+                <num_bids> 0</num_bids>
+                <started_at> $650.00</started_at>
+                <bid_increment> </bid_increment>
+                <location> SulphurSprings, Texas, United States</location>
+                <opened> 11/15/00 5:10:41 PM</opened>
+                <closed> 11/30/00 5:10:41 PM</closed>
+                <id_num> 294559</id_num>
+                <notes> </notes>
+            </auction_info>
+            <bid_history>
+                <highest_bid_amount>$650.00 </highest_bid_amount>
+                <quantity>0 </quantity>
+            </bid_history>
+            <item_info>
+                <memory> 32 mb.</memory>
+                <hard_drive> 10.2 gb.</hard_drive>
+                <cpu> 500 mhz</cpu>
+                <brand> Gateway</brand>
+                <description> A nearly new Gateway Essentials 500 mhz. complete system. with windows 98 2nd. edition pre-installed and operating system cd and system restoration cd plus some other software with original cds. and manuals including the windows 98 operating system manual plus other documentation. including a 15 inch color EV500 monitor, 32 mb. of ram , a 10.2 gb. hd. 44x panasonic cdrom , a 56k modem ,pci soundcards and sound blaster video cards . A mic. a 104key internet keyboard. a wheel mouse, altech-lansing speakers, &amp; much more almost new had since April of this year. buyer Must be willing to pay the shipping costs of aprox.55.00 depending on shipper which is the buyers choice . but item will not be shipped until payment is recieved in full. no debit cards or bank drafts please? all other payment options are fine. so if intrested please contact me asap ? or 321gone.com ? and thank you and have a nice day! p.s. it has a intel celeron processor with it Eq. to a pent 3 . </description>
+            </item_info>
+        </listing>
+        <listing>
+            <seller_info>
+                <seller_name> lapro8</seller_name>
+                <seller_rating> 0</seller_rating>
+            </seller_info>
+            <payment_types>Money Order </payment_types>
+            <shipping_info>International Shipping, See Shipping Description </shipping_info>
+            <buyer_protection_info> </buyer_protection_info>
+            <auction_info>
+                <current_bid> $320.00</current_bid>
+                <time_left> 4 Days, 21 Hrs</time_left>
+                <high_bidder>
+                    <bidder_name> </bidder_name>
+                    <bidder_rating> </bidder_rating>
+                </high_bidder>
+                <num_items> 1</num_items>
+                <num_bids> 0</num_bids>
+                <started_at> $320.00</started_at>
+                <bid_increment> $5.00</bid_increment>
+                <location> Cherkasy, Ukraine</location>
+                <opened> 11/27/00 11:18:36 AM</opened>
+                <closed> 12/2/00 11:18:36 AM</closed>
+                <id_num> 320764</id_num>
+                <notes> </notes>
+            </auction_info>
+            <bid_history>
+                <highest_bid_amount>$320.00 </highest_bid_amount>
+                <quantity> 0</quantity>
+            </bid_history>
+            <item_info>
+                <memory> 64 MB of SDRAM</memory>
+                <hard_drive> 6.4 GB</hard_drive>
+                <cpu> Pentium 300 MHz processor with MMX technology </cpu>
+                <brand> VAIO</brand>
+                <description> A SuperSlim notebook computer that's light on weight, heavy on features and performance *This .9 thin Notebook Computer weighs in at roughly 3 pounds - which might make you wonder how they cram such great features into that small package *10.4 XGA Active matrix screen with XBRITE display technology *Intel Pentium 300 MHz processor with MMX technology *64 MB of SDRAM is included (expandable to 128 MB maximum) *6.4 GB fixed Hard Drive for Data Storage *Touch Pad with pen operation *One Type II PC card slot with Cardbus Zoomed Video support *External 1.44 MB floppy disk drive *integrated 56K V.90 Data/fax Modem for Internet access *512 KB MultiBank DRAM Cache memory *16-bit, Soundblaster compatible audio *MPEG1 Digital video that supports full screen playback *mono speakers *Built-in microphone *Infrared port *Responsive nearly full-size tactile Keyboard *programmable power key for unattended Email retrieval Please add $30 for shipping. Payment - western union. </description>
+            </item_info>
+        </listing>
+    </root>
 </foo>

--- a/src/test/resources/owasp-dependency-check.xml
+++ b/src/test/resources/owasp-dependency-check.xml
@@ -3,7 +3,7 @@
     <suppress>
         <notes>
             We are on Camel >= 4.7.0, so we are not affected.
-            The plugin thinks we are affected because we use org.apache.camel.quarkus:camel-quarkus-xpath 3.13.0.
+            The plugin thinks we are affected because we use org.apache.camel.quarkus:* in version 3.13.0.
         </notes>
         <cve>CVE-2023-34442</cve>
     </suppress>


### PR DESCRIPTION
Performance Optimizations:
- Use immutable collections instead of unmodifiable collections where possible
- Instead of exposing the full path, only expose the depth (we need nothing else right now)
- Return lists instead of sets
- Accept collections instead of Lists
- Use a larger file (https://aiweb.cs.washington.edu/research/projects/xmltk/xmldata/data/auctions/321gone.xml) for testing